### PR TITLE
Fix SDL2: use GLM to restore functionality.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,13 @@ set_package_properties(SDL2 PROPERTIES
     TYPE REQUIRED
 )
 
+find_package(GLM REQUIRED)
+set_package_properties(GLM PROPERTIES
+    URL "https://glm.g-truc.net/"
+    DESCRIPTION "OpenGL Mathematics library"
+    TYPE REQUIRED
+)
+
 find_package(ZLIB REQUIRED)
 set_package_properties(ZLIB PROPERTIES
     URL "http://www.zlib.net"
@@ -61,7 +68,7 @@ include_directories(${STRING_THEORY_INCLUDE_DIRS})
 feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
 include_directories(${GLEW_INCLUDE_DIR})
 include_directories(${OPENGL_INCLUDE_DIR})
-include_directories(${SDL2_INCLUDE_DIRS})
+include_directories(${GLM_INCLUDE_DIRS})
 include_directories(${ZLIB_INCLUDE_DIR})
 
 # 3rd party Squish library for DXT codecs

--- a/cmake/FindGLM.cmake
+++ b/cmake/FindGLM.cmake
@@ -1,0 +1,52 @@
+#
+# Find GLM
+#
+# Try to find GLM : OpenGL Mathematics.
+# This module defines
+# - GLM_INCLUDE_DIRS
+# - GLM_FOUND
+#
+# The following variables can be set as arguments for the module.
+# - GLM_ROOT_DIR : Root library directory of GLM
+#
+# References:
+# - https://github.com/Groovounet/glm/blob/master/util/FindGLM.cmake
+# - https://bitbucket.org/alfonse/gltut/src/28636298c1c0/glm-0.9.0.7/FindGLM.cmake
+#
+
+# Additional modules
+include(FindPackageHandleStandardArgs)
+
+if (WIN32)
+    # Find include files
+    find_path(
+        GLM_INCLUDE_DIR
+        NAMES glm/glm.hpp
+        PATHS
+        $ENV{PROGRAMFILES}/include
+        ${GLM_ROOT_DIR}/include
+        DOC "The directory where glm/glm.hpp resides")
+else()
+    # Find include files
+    find_path(
+        GLM_INCLUDE_DIR
+        NAMES glm/glm.hpp
+        PATHS
+        /usr/include
+        /usr/local/include
+        /sw/include
+        /opt/local/include
+        ${GLM_ROOT_DIR}/include
+        DOC "The directory where glm/glm.hpp resides")
+endif()
+
+# Handle REQUIRED argument, define *_FOUND variable
+find_package_handle_standard_args(GLM DEFAULT_MSG GLM_INCLUDE_DIR)
+
+# Define GLM_INCLUDE_DIRS
+if (GLM_FOUND)
+    set(GLM_INCLUDE_DIRS ${GLM_INCLUDE_DIR})
+endif()
+
+# Hide some variables
+mark_as_advanced(GLM_INCLUDE_DIR)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,7 +40,7 @@ source_group("Source Files" FILES ${imCommon_SOURCES})
 
 add_executable(imaginaryMyst WIN32 ${imCommon_HEADERS} ${imCommon_SOURCES})
 target_link_libraries(imaginaryMyst imAnim imScene imSound imSurface imVfs)
-target_link_libraries(imaginaryMyst squish SDL2 SDL2main)
+target_link_libraries(imaginaryMyst squish SDL2::SDL2 SDL2::SDL2main)
 target_link_libraries(imaginaryMyst ${OPENGL_LIBRARIES})
 target_link_libraries(imaginaryMyst ${ZLIB_LIBRARIES})
 target_link_libraries(imaginaryMyst ${STRING_THEORY_LIBRARIES})

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -15,11 +15,14 @@
  */
 
 #include <iostream>
-#include <GL/glu.h>
 #include "imCommon.h"
 #include "scene/imSceneDatabase.h"
 #include "scene/imSceneIndex.h"
 #include "surface/imMipmap.h"
+
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/type_ptr.hpp>
 
 #ifdef WIN32
 #  include <windows.h>
@@ -142,10 +145,17 @@ int main(int argc, char *argv[])
     }
 
     // Create a window for the game
-    s_display = SDL_CreateWindow("imaginaryMyst Alpha", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, winWidth,
-                                 winHeight, SDL_WINDOW_OPENGL);
-
+    s_display = SDL_CreateWindow("imaginaryMyst Alpha",
+                          SDL_WINDOWPOS_CENTERED,
+                          SDL_WINDOWPOS_CENTERED,
+                          winWidth, winHeight,
+                          SDL_WINDOW_OPENGL);
     SDL_GLContext glContext = SDL_GL_CreateContext(s_display);
+    glm::mat4 projection = glm::perspective(
+      45.0f,                                // FoV
+      (float)winWidth / (float)winHeight,   // Aspect Ratio
+      0.1f,                                 // Near Plane
+      10000.0f);                            // Far Plane
 
     GLX_CompressedTexImage2D = (PFNGLCOMPRESSEDTEXIMAGE2DARBPROC)
             SDL_GL_GetProcAddress("glCompressedTexImage2DARB");
@@ -158,7 +168,7 @@ int main(int argc, char *argv[])
     glViewport(0, 0, winWidth, winHeight);
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
-    gluPerspective(45.0f, (static_cast<float>(winWidth)) / (static_cast<float>(winHeight)), 0.1f, 10000.0f);
+    glLoadMatrixf(glm::value_ptr(projection));
     glEnable(GL_TEXTURE_2D);
     glDisable(GL_CULL_FACE);
     glEnable(GL_BLEND);
@@ -176,7 +186,6 @@ int main(int argc, char *argv[])
     } else {
         imLog("Error reading HSM file");
     }
-    //img.TEST_ExportDDS("test.dds");
 
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     glTranslatef(0.0f, 0.0f, -4.0f);
@@ -196,6 +205,7 @@ int main(int argc, char *argv[])
     SDL_GL_SwapWindow(s_display);
     SDL_Delay(3000);
     SDL_GL_DeleteContext(glContext);
+    SDL_DestroyWindow(s_display);
 
     SDL_Quit();
     return 0;

--- a/src/anim/CMakeLists.txt
+++ b/src/anim/CMakeLists.txt
@@ -32,3 +32,4 @@ source_group("Source Files" FILES ${imAnim_SOURCES})
 
 add_library(imAnim STATIC ${imAnim_HEADERS} ${imAnim_SOURCES})
 target_link_libraries(imAnim imVfs)
+target_link_libraries(imAnim SDL2::SDL2)

--- a/src/sound/CMakeLists.txt
+++ b/src/sound/CMakeLists.txt
@@ -25,3 +25,4 @@ source_group("Header Files" FILES ${imSound_HEADERS})
 source_group("Source Files" FILES ${imSound_SOURCES})
 
 add_library(imSound STATIC ${imSound_HEADERS} ${imSound_SOURCES})
+target_link_libraries(imSound SDL2::SDL2)

--- a/src/surface/CMakeLists.txt
+++ b/src/surface/CMakeLists.txt
@@ -35,4 +35,4 @@ source_group("Source Files" FILES ${imSurface_SOURCES})
 add_library(imSurface STATIC ${imSurface_HEADERS} ${imSurface_SOURCES})
 target_link_libraries(imSurface imAnim)
 target_link_libraries(imSurface imScene)    # WARNING: Circular dependency!
-target_link_libraries(imSurface squish)
+target_link_libraries(imSurface squish SDL2::SDL2)


### PR DESCRIPTION
This fixes compilation with SDL2, and uses GLM to replace deprecated functions and provide GL math features going forward.