### PR TITLE
Find SDL2 correctly even if it was built with Autotools instead of CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,16 @@ set_package_properties(SDL2 PROPERTIES
     DESCRIPTION "Simple DirectMedia Layer"
     TYPE REQUIRED
 )
+if(SDL2_FOUND AND TARGET SDL2::SDL2)
+    # Map the CMake-style export targets to the classic variables
+    # used by the autotools-generated CMake configuration.
+    get_target_property(SDL2_INCLUDE_DIRS SDL2::SDL2 INTERFACE_INCLUDE_DIRECTORIES)
+    set(SDL2_LIBRARIES SDL2::SDL2 SDL2::SDL2main)
+else()
+    # The autotools-generated cmake file may contain trailing whitespace,
+    # which is treated as an error in CMake with CMP0004
+    string(STRIP "${SDL2_LIBRARIES}" SDL2_LIBRARIES)
+endif()
 
 find_package(GLM REQUIRED)
 set_package_properties(GLM PROPERTIES
@@ -69,6 +79,7 @@ feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
 include_directories(${GLEW_INCLUDE_DIR})
 include_directories(${OPENGL_INCLUDE_DIR})
 include_directories(${GLM_INCLUDE_DIRS})
+include_directories(${SDL2_INCLUDE_DIRS})
 include_directories(${ZLIB_INCLUDE_DIR})
 
 # 3rd party Squish library for DXT codecs

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,7 +40,7 @@ source_group("Source Files" FILES ${imCommon_SOURCES})
 
 add_executable(imaginaryMyst WIN32 ${imCommon_HEADERS} ${imCommon_SOURCES})
 target_link_libraries(imaginaryMyst imAnim imScene imSound imSurface imVfs)
-target_link_libraries(imaginaryMyst squish SDL2::SDL2 SDL2::SDL2main)
+target_link_libraries(imaginaryMyst squish ${SDL2_LIBRARIES})
 target_link_libraries(imaginaryMyst ${OPENGL_LIBRARIES})
 target_link_libraries(imaginaryMyst ${ZLIB_LIBRARIES})
 target_link_libraries(imaginaryMyst ${STRING_THEORY_LIBRARIES})

--- a/src/anim/CMakeLists.txt
+++ b/src/anim/CMakeLists.txt
@@ -32,4 +32,3 @@ source_group("Source Files" FILES ${imAnim_SOURCES})
 
 add_library(imAnim STATIC ${imAnim_HEADERS} ${imAnim_SOURCES})
 target_link_libraries(imAnim imVfs)
-target_link_libraries(imAnim SDL2::SDL2)

--- a/src/sound/CMakeLists.txt
+++ b/src/sound/CMakeLists.txt
@@ -25,4 +25,3 @@ source_group("Header Files" FILES ${imSound_HEADERS})
 source_group("Source Files" FILES ${imSound_SOURCES})
 
 add_library(imSound STATIC ${imSound_HEADERS} ${imSound_SOURCES})
-target_link_libraries(imSound SDL2::SDL2)

--- a/src/surface/CMakeLists.txt
+++ b/src/surface/CMakeLists.txt
@@ -35,4 +35,4 @@ source_group("Source Files" FILES ${imSurface_SOURCES})
 add_library(imSurface STATIC ${imSurface_HEADERS} ${imSurface_SOURCES})
 target_link_libraries(imSurface imAnim)
 target_link_libraries(imSurface imScene)    # WARNING: Circular dependency!
-target_link_libraries(imSurface squish SDL2::SDL2)
+target_link_libraries(imSurface squish)


### PR DESCRIPTION
This fixes compatibility with the sdl2 library that ships with Debian, Ubuntu and probably others.